### PR TITLE
Ulusal Teknoloji Madalyası görseli

### DIFF
--- a/_posts/2015-02-19-unix-ve-benzerlerinin-kronolojisi.html
+++ b/_posts/2015-02-19-unix-ve-benzerlerinin-kronolojisi.html
@@ -161,7 +161,7 @@ keywords:
 	<dd>
 		Ken Thompson ve Dennis Ritchie Ulusal Teknoloji Madalyası'nı(National Medal of Technology) kazanırlar.
 
-		<img src="http://upload.wikimedia.org/wikipedia/commons/0/08/Medal_lg.jpeg" style="display:block; margin:40px auto; width: 60%"/>
+		<img src="http://media-2.web.britannica.com/eb-media/24/140324-004-D1D105D0.jpg" style="display:block; margin:40px auto; width: 60%"/>
 	</dd>
 
 	<dt>2000</dt>


### PR DESCRIPTION
Ulusal Teknoloji Madalyası görseli artık kaynağında bulunmuyor. İlk başta eski görselin madalya görseli olduğunu düşündüm ama sonra Ken Thompson ve Dennis Ritchie'nin madalyayı alırken çekilen bir fotoğrafın olması daha mantıklıdır diye düşündüm. Umarım doğru görseli koymuşumdur.